### PR TITLE
FIX: Storybook danger 컬러 옛날 이름으로 되어있어서 수정

### DIFF
--- a/apps/storybook/stories/styles/Color.stories.tsx
+++ b/apps/storybook/stories/styles/Color.stories.tsx
@@ -3,7 +3,7 @@ import {
   Brand as _Brand,
   Primary as _Primary,
   Secondary as _Secondary,
-  ErrorColor,
+  DangerColor,
 } from "@ddal-kkak/ui/styles";
 
 const meta: Meta = {
@@ -24,6 +24,6 @@ export const Secondary = {
   render: () => <_Secondary />,
 };
 
-export const Error = {
-  render: () => <ErrorColor />,
+export const Danger = {
+  render: () => <DangerColor />,
 };

--- a/packages/ui/src/styles/colors.tsx
+++ b/packages/ui/src/styles/colors.tsx
@@ -27,11 +27,11 @@ export function Secondary() {
   );
 }
 
-export function ErrorColor() {
+export function DangerColor() {
   return (
     <div>
-      <Square className={"bg-error-01"} />
-      <Square className={"bg-error-02"} />
+      <Square className={"bg-danger-01"} />
+      <Square className={"bg-danger-02"} />
     </div>
   );
 }


### PR DESCRIPTION
### Changes
- 기본 스타일에서 빨간색 이름이 error => danger 로 변경되어서 컬러가 노출 안되고 있어서 수정하였음

### Screenshots


### Test Checklist
- 

### Link
- 테크스펙 :
- Figma :
- Ticket :
- 기타 : 
