### PR TITLE
페이지 정보 기본 스키마 예시 코드 추가

### DIFF
--- a/apps/ddal-kkak/app/block/edit/_components/form.tsx
+++ b/apps/ddal-kkak/app/block/edit/_components/form.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { useFieldArray, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button, Input } from "@ddal-kkak/ui/atoms";
+import { PageSchema } from "../../../../schema";
+
+type PageSchemaType = z.infer<typeof PageSchema>;
+
+export default function TestForm() {
+  const method = useForm<PageSchemaType>({
+    resolver: zodResolver(PageSchema),
+  });
+  const { register, control } = method;
+
+  const { fields, append } = useFieldArray({
+    control,
+    name: "metaTagList",
+  });
+
+  const handleSubmit = (data: PageSchemaType) => {
+    console.log(data);
+  };
+
+  return (
+    <>
+      <Button
+        type={"button"}
+        onClick={() =>
+          append({
+            property: "",
+            content: "",
+          })
+        }
+      >
+        추가
+      </Button>
+      <form
+        {...method}
+        onSubmit={method.handleSubmit(handleSubmit)}
+        className={"flex flex-col"}
+      >
+        <label htmlFor="">
+          title
+          <Input type="text" {...register("info.title")} />
+        </label>
+        <label>
+          slug
+          <Input type="text" {...register("info.slug")} />
+        </label>
+        <label>
+          meta
+          <Input type="text" {...register(`metaTagList.0.property`)} />
+        </label>
+        <label htmlFor="">
+          content
+          <Input type="text" {...register(`metaTagList.0.content`)} />
+        </label>
+        {fields.map((field, index) => (
+          <>
+            <label>
+              meta
+              <Input
+                type="text"
+                key={field.id}
+                {...register(`metaTagList.${index}.property`)}
+              />
+            </label>
+            <label htmlFor="">
+              content
+              <Input
+                type="text"
+                key={field.id}
+                {...register(`metaTagList.${index}.content`)}
+              />
+            </label>
+          </>
+        ))}
+        <Button>제출</Button>
+      </form>
+    </>
+  );
+}

--- a/apps/ddal-kkak/app/block/edit/_components/form.tsx
+++ b/apps/ddal-kkak/app/block/edit/_components/form.tsx
@@ -56,7 +56,7 @@ export default function TestForm() {
           content
           <Input type="text" {...register(`metaTagList.0.content`)} />
         </label>
-        {fields.map((field, index) => (
+        {fields.map((field, index + 1) => (
           <>
             <label>
               meta

--- a/apps/ddal-kkak/app/block/edit/_components/form.tsx
+++ b/apps/ddal-kkak/app/block/edit/_components/form.tsx
@@ -56,14 +56,14 @@ export default function TestForm() {
           content
           <Input type="text" {...register(`metaTagList.0.content`)} />
         </label>
-        {fields.map((field, index + 1) => (
+        {fields.map((field, index) => (
           <>
             <label>
               meta
               <Input
                 type="text"
                 key={field.id}
-                {...register(`metaTagList.${index}.property`)}
+                {...register(`metaTagList.${index + 1}.property`)}
               />
             </label>
             <label htmlFor="">
@@ -71,7 +71,7 @@ export default function TestForm() {
               <Input
                 type="text"
                 key={field.id}
-                {...register(`metaTagList.${index}.content`)}
+                {...register(`metaTagList.${index + 1}.content`)}
               />
             </label>
           </>

--- a/apps/ddal-kkak/app/block/edit/page.tsx
+++ b/apps/ddal-kkak/app/block/edit/page.tsx
@@ -1,3 +1,5 @@
+import TestForm from "./_components/form";
+
 export default function BlockEditPage() {
-  return <div>page</div>
+  return <TestForm />;
 }

--- a/apps/ddal-kkak/package.json
+++ b/apps/ddal-kkak/package.json
@@ -13,9 +13,12 @@
   "dependencies": {
     "@ddal-kkak/tailwind-config": "workspace:^",
     "@ddal-kkak/ui": "workspace:*",
+    "@hookform/resolvers": "^3.3.4",
     "next": "^14.1.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.51.3",
+    "zod": "^3.23.5"
   },
   "devDependencies": {
     "@ddal-kkak/eslint-config": "workspace:*",

--- a/apps/ddal-kkak/schema/editor.ts
+++ b/apps/ddal-kkak/schema/editor.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+const ERROR_MESSAGE = {
+  REQUIRED: "필수임",
+};
+
+export const InfoSchema = z.object({
+  title: z.string().min(1, ERROR_MESSAGE.REQUIRED),
+  slug: z.string().min(1, ERROR_MESSAGE.REQUIRED),
+});
+
+export const MetaTagSchema = z.object({
+  property: z.string().min(1),
+  content: z.string().min(1),
+});
+
+export const PageSchema = z.object({
+  info: InfoSchema,
+  metaTagList: z.array(MetaTagSchema),
+});

--- a/apps/ddal-kkak/schema/index.ts
+++ b/apps/ddal-kkak/schema/index.ts
@@ -1,0 +1,1 @@
+export * from "./editor";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@ddal-kkak/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@hookform/resolvers':
+        specifier: ^3.3.4
+        version: 3.3.4(react-hook-form@7.51.3)
       next:
         specifier: ^14.1.1
         version: 14.2.3(@babel/core@7.24.5)(react-dom@18.3.1)(react@18.3.1)
@@ -44,6 +47,12 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.51.3
+        version: 7.51.3(react@18.3.1)
+      zod:
+        specifier: ^3.23.5
+        version: 3.23.5
     devDependencies:
       '@ddal-kkak/eslint-config':
         specifier: workspace:*
@@ -1888,6 +1897,14 @@ packages:
   /@fal-works/esbuild-plugin-global-externals@2.1.2:
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
     dev: true
+
+  /@hookform/resolvers@3.3.4(react-hook-form@7.51.3):
+    resolution: {integrity: sha512-o5cgpGOuJYrd+iMKvkttOclgwRW86EsWJZZRC23prf0uU2i48Htq4PuT73AVb9ionFyZrwYEITuOFGF+BydEtQ==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
+    dependencies:
+      react-hook-form: 7.51.3(react@18.3.1)
+    dev: false
 
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -8691,6 +8708,15 @@ packages:
       react-is: 18.1.0
     dev: true
 
+  /react-hook-form@7.51.3(react@18.3.1):
+    resolution: {integrity: sha512-cvJ/wbHdhYx8aviSWh28w9ImjmVsb5Y05n1+FW786vEZQJV5STNM0pW6ujS+oiBecb0ARBxJFyAnXj9+GHXACQ==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dependencies:
+      react: 18.3.1
+    dev: false
+
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: true
@@ -10610,3 +10636,7 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+  /zod@3.23.5:
+    resolution: {integrity: sha512-fkwiq0VIQTksNNA131rDOsVJcns0pfVUjHzLrNBiF/O/Xxb5lQyEXkhZWcJ7npWsYlvs+h0jFWXXy4X46Em1JA==}
+    dev: false


### PR DESCRIPTION
### Changes
- 기본 스키마 추가염
- info => 페이지의 핵심 정보 (타이틀, slug)
- meta => 메타테그를 관리하는 스키마

예시 코드고요 이거 보고 하세요

### Screenshots


### Test Checklist
- 

### Link
- 테크스펙 :
- Figma :
- Ticket :
- 기타 : 
